### PR TITLE
helmchart - add existingSecret functionality

### DIFF
--- a/docker/kubernetes/helm/templates/api/deployment.yaml
+++ b/docker/kubernetes/helm/templates/api/deployment.yaml
@@ -147,18 +147,18 @@ spec:
                   key: accessKey
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom :
-               secretKeyRef:
+                secretKeyRef:
                   name: {{ include "novu.s3.secretName" . }}
                   key: secretKey
             - name: JWT_SECRET
               valueFrom :
-               secretKeyRef:
-                  name: {{ include "common.names.fullname" . }}
+                secretKeyRef:
+                  name: {{ if .Values.existingSecret -}} {{ .Values.existingSecret }} {{- else -}} {{ include "common.names.fullname" . }} {{- end }}
                   key: jwt-secret
             - name: STORE_ENCRYPTION_KEY
               valueFrom :
-               secretKeyRef:
-                  name: {{ include "common.names.fullname" . }}
+                secretKeyRef:
+                  name: {{ if .Values.existingSecret -}} {{ .Values.existingSecret }} {{- else -}} {{ include "common.names.fullname" . }} {{- end }}
                   key: store-encryption-key
             {{- if .Values.api.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.api.extraEnvVars "context" $) | nindent 12 }}

--- a/docker/kubernetes/helm/templates/worker/deployment.yaml
+++ b/docker/kubernetes/helm/templates/worker/deployment.yaml
@@ -126,28 +126,28 @@ spec:
                   key: mongoUrl
             - name: S3_BUCKET_NAME
               valueFrom :
-               secretKeyRef:
+                secretKeyRef:
                   name: {{ include "novu.s3.secretName" . }}
                   key: bucketName
             - name: S3_REGION
               valueFrom :
-               secretKeyRef:
+                secretKeyRef:
                   name: {{ include "novu.s3.secretName" . }}
                   key: region
             - name: AWS_ACCESS_KEY_ID
               valueFrom :
-               secretKeyRef:
+                secretKeyRef:
                   name: {{ include "novu.s3.secretName" . }}
                   key: accessKey
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom :
-               secretKeyRef:
+                secretKeyRef:
                   name: {{ include "novu.s3.secretName" . }}
                   key: secretKey
             - name: STORE_ENCRYPTION_KEY
               valueFrom :
-               secretKeyRef:
-                  name: {{ include "common.names.fullname" . }}
+                secretKeyRef:
+                  name: {{ if .Values.existingSecret -}} {{ .Values.existingSecret }} {{- else -}} {{ include "common.names.fullname" . }} {{- end }}
                   key: store-encryption-key
             {{- if .Values.api.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.api.extraEnvVars "context" $) | nindent 12 }}

--- a/docker/kubernetes/helm/templates/ws/deployment.yaml
+++ b/docker/kubernetes/helm/templates/ws/deployment.yaml
@@ -115,8 +115,8 @@ spec:
                   key: mongoUrl
             - name: JWT_SECRET
               valueFrom :
-               secretKeyRef:
-                  name: {{ include "common.names.fullname" . }}
+                secretKeyRef:
+                  name: {{ if .Values.existingSecret -}} {{ .Values.existingSecret }} {{- else -}} {{ include "common.names.fullname" . }} {{- end }}
                   key: jwt-secret
             {{- if .Values.ws.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.api.extraEnvVars "context" $) | nindent 12 }}

--- a/docker/kubernetes/helm/values.yaml
+++ b/docker/kubernetes/helm/values.yaml
@@ -1695,6 +1695,8 @@ metrics:
 
 ##@section Secrets definition
 ##
+existingSecret: ''
+
 jwt:
   ## @param jwt.secret The secret keybase which is used to encrypt / verify the tokens issued for authentication
   ## Please change this for production use !


### PR DESCRIPTION
### What changed? Why was the change needed?

`existingSecret` functionality was added

rendering of the secret from _secret.yaml_  was already conditioned using `.Values.existingSecret`
however the functionality **is not there**
